### PR TITLE
Twitter Card対応

### DIFF
--- a/cmd-chan/icons.html
+++ b/cmd-chan/icons.html
@@ -8,6 +8,12 @@
 	<meta name="author" content="keepoff07">
 	<meta name="description" content="">
 	
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:site" content="@keep_off07">
+	<meta name="twitter:title" content="コマンドブロックちゃんのアイコン置き場">
+	<meta name="twitter:description" content="Minecraftに登場するコマンドブロックの擬人化、「コマンドブロックちゃん」のアイコン置き場です">
+	<meta name="twitter:image" content="http://i.imgur.com/0JKSkFa.png">
+	
 	<script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
 	<script src="//code.jquery.com/jquery-2.1.4.js"></script>
 	


### PR DESCRIPTION
[`cmd-chan/icons.html`](http://keepoff07.github.io/cmd-chan/icons)を[Twitter Cards](https://dev.twitter.com/ja/cards/overview)に対応させました

## サンプル

![2015-11-20_20-57-00](https://cloud.githubusercontent.com/assets/4990822/11299402/df63cd04-8fc9-11e5-9bc8-80cb559248bd.png)

## 注意

マージ後に<https://cards-dev.twitter.com/validator>で一度`Preview card`し、ホワイトリストに登録しないと反映されません。