### PR TITLE
ナビゲーションバーのツイートボタンを旧仕様風に変更

### DIFF
--- a/nuitter/share.html
+++ b/nuitter/share.html
@@ -87,13 +87,14 @@
 				<div id="button-toggle" class="collapse navbar-collapse">
 					<ul class="nav navbar-nav navbar-right">
 						<li>
-							<div id="social-button">
-								<a href="https://twitter.com/share" class="twitter-share-button" data-url="https://keepoff07.github.io/nuitter/share" data-text="Nuitter - 抜いたことをシェアしよう" data-via="keep_off07" data-lang="en" data-hashtags="Nuitter">Tweet</a>
-								<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+							<div class="social-button">
+								<a href="https://twitter.com/intent/tweet?text=Nuitter%20-%20%E6%8A%9C%E3%81%84%E3%81%9F%E3%81%93%E3%81%A8%E3%82%92%E3%82%B7%E3%82%A7%E3%82%A2%E3%81%97%E3%82%88%E3%81%86&url=https%3A%2F%2Fkeepoff07.github.io%2Fnuitter%2Fshare&via=keep_off07&hashtags=Nuitter" class="btn-custom" role="button">
+									<i class="fa fa-lg fa-twitter fa-fw" style="color: #1b95e0"></i>Tweet
+								</a>
 							</div>
 						</li>
 						<li>
-							<div id="social-button">
+							<div class="social-button">
 								<a class="github-button" href="https://github.com/keepoff07/keepoff07.github.io/fork" data-count-href="/keepoff07/keepoff07.github.io/network" data-count-api="/repos/keepoff07/keepoff07.github.io#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork keepoff07/keepoff07.github.io on GitHub">Fork</a>
 								<script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
 							</div>

--- a/nuitter/style.less
+++ b/nuitter/style.less
@@ -74,7 +74,7 @@ body > .container {
 	margin: 0 auto 15 auto !important;
 }
 
-#social-button {
+.social-button {
 	padding-top: 15px;
 	margin-right: 10px;
 	.in & { padding-top: 5px; padding-bottom: 5px; margin-left: 10px; }
@@ -103,5 +103,35 @@ body > .container {
 		width: 100%;
 		display: table-cell;
 		vertical-align: middle;
+	}
+}
+
+.btn-custom {
+	display: inline-block;
+	height: 20px;
+	vertical-align: middle;
+	font-weight: bold;
+	font-size: 11px;
+	color: #333;
+	text-shadow: 0 1px 0 rgba(255,255,255,0.5);
+	cursor: pointer;
+	background-color: #eee;
+	background-image: -webkit-linear-gradient(#fff,#dedede);
+	background-image: linear-gradient(#fff,#dedede);
+	border: #ccc solid 1px;
+	border-radius: 3px;
+	padding: 1px 4px 0 3px;
+
+	&:hover, &:focus, &:active {
+		background-color: #d9d9d9;
+		background-image: -webkit-linear-gradient(#f8f8f8,#d9d9d9);
+		background-image: linear-gradient(#f8f8f8,#d9d9d9);
+		border-color: #bbb;
+		box-shadow: none;
+	}
+
+	&:hover, &:active, &:focus {
+		text-decoration: none;
+		color: inherit;
 	}
 }


### PR DESCRIPTION
<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/4990822/11497565/310ff894-985d-11e5-9cca-e1f915410e51.gif"><br><br>
  ぷ... プルリクエストです！ 昨日Qiitaでやってたアドベントで見たんです！
</p>

---

* 無意味なid扱いになっていた`#social-button`を`.social-button`へ変更
* `.btn-custom`を新しく定義

## preview

![2015-12-01_18-36-12](https://cloud.githubusercontent.com/assets/4990822/11497239/07673e78-985b-11e5-885f-cbc01845dac1.png)
